### PR TITLE
Allow HTML in tooltip

### DIFF
--- a/src/SvelteTooltip.svelte
+++ b/src/SvelteTooltip.svelte
@@ -79,6 +79,6 @@
     class:top
     style={style}
   >
-    {tip}
+    {@html tip}
   </span>
 </div>


### PR DESCRIPTION
This PR makes a tiny change to allow tooltip templates to have HTML in them. 