### PR TITLE
Allow tip to contain html content

### DIFF
--- a/src/SvelteTooltip.svelte
+++ b/src/SvelteTooltip.svelte
@@ -81,7 +81,7 @@
     class:bottom
     class:top>
     {#if tip}
-      <div class="default-tip" {style}>{tip}</div>
+      <div class="default-tip" {style}>{@html tip}</div>
     {:else}
       <slot name="custom-tip" />
     {/if}


### PR DESCRIPTION
Allow the tip content to contain html such as <br> tags.